### PR TITLE
Update resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ The list is still incomplete, any additional resources for existing sections or 
 
 ## General trainings and books
 
- - Scala exercises https://www.scala-exercises.org/scala_tutorial/terms_and_types
+ - Scala Exercises https://www.scala-exercises.org/scala_tutorial/terms_and_types
  - Scala at Light Speed https://www.youtube.com/watch?v=-8V6bMjThNo&list=PLmtsMNDRU0BxryRX4wiwrTZ661xcp6VPM
- - (paid) Rock The JVM https://rockthejvm.com
- - (paid, free preview) Hands on Scala by Li Haoi https://www.handsonscala.com/chapter-1-hands-on-scala.html
- - Scala with Cats by Underscore https://www.scalawithcats.com/dist/scala-with-cats.html 
+ - Foundations of Functional Programming in Scala https://www.youtube.com/watch?v=OdPaWmRnAc4&list=PLiYD0LWExCDkXGpYRY3WjNscDfhe4D0ND
+ - Functional Programming Strategies in Scala with Cats by Noel Welsh https://www.scalawithcats.com/dist/scala-with-cats.html
+ - Practical FP in Scala by Gabriel Volpe (free / pay any price) https://leanpub.com/pfp-scala
  - Functional Programming in Scala by Martin Odersky https://www.coursera.org/learn/progfun1 
  - Strategic Scala Style: Principle of Least Power by Li Haoi https://www.lihaoyi.com/post/StrategicScalaStylePrincipleofLeastPower.html 
- - Lightbend Scala Language - Professional https://academy.lightbend.com/courses/course-v1:lightbend+LSL-P-Scala-Language-Professional+v1/about 
- - Foundations of Functional Programming in Scala https://www.youtube.com/watch?v=OdPaWmRnAc4&list=PLiYD0LWExCDkXGpYRY3WjNscDfhe4D0ND
- - (paid) Inner-product training https://www.inner-product.com/services/training/
  - Functional Stream Processing in Scala by Zainab Ali https://pureasync.gumroad.com/l/functional-stream-processing-in-scala
  - Learn Scala 3, Functional Programming and ZIO 2 by Alvin Alexander https://www.learnscala.dev/
+
+Paid:
+
+ - Rock The JVM https://rockthejvm.com
+ - (free preview) Hands on Scala by Li Haoi https://www.handsonscala.com/chapter-1-hands-on-scala.html
+ - Inner-product training https://www.inner-product.com/services/training/
 
 ---
 


### PR DESCRIPTION
- Lightbend scala course is gone, the link now redirects to akkademy which doesn't have a scala course
- moved paid content to their own section
- added Gabriel's book which is now free
- moved Julien's course higher as it's more beginner focused than some links that used to be above
- the current Scala with Cats has a different name and isn't published by Underscore, website says "by Noel Welsh, published by Inner Product" so just using the author's name